### PR TITLE
[DATA-101] Fix eslint peer dependency and make npm run test-browser execute npm run build first

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "lint": "eslint src test",
     "test": "mocha --compilers js:babel-core/register --require babel-polyfill test/node",
-    "test-browser": "karma start --single-run",
+    "test-browser": "npm run build && karma start --single-run",
     "build": "webpack"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "babel-polyfill": "^6.7.2",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
-    "eslint": "^2.4.0",
+    "eslint": "~2.2.0",
     "eslint-plugin-mocha": "^2.0.0",
     "estraverse-fb": "^1.3.1",
     "karma": "^0.13.22",


### PR DESCRIPTION
To verify, clone down the fresh repo and run `npm install`. No errors should occur.

Next, run `npm run test-browser`. Tests should pass (after building the webpack bundle).