### PR TITLE
Remove .end() from superagent calls

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -23,8 +23,7 @@ export default class Client {
       .post(this.config.endpoint + '/login')
       .auth(username, password)
       .accept('application/json')
-      .use(promise)
-      .end();
+      .use(promise);
     if (response.status == 200)
       return this._tokens(response.body);
     else
@@ -40,8 +39,7 @@ export default class Client {
       .type('application/json')
       .accept('application/json')
       .send({refresh_token})
-      .use(promise)
-      .end();
+      .use(promise);
     if (response.status == 200)
       return this._tokens(response.body);
     else
@@ -56,8 +54,7 @@ export default class Client {
       const response = await request
         .post(this.config.endpoint + '/logout')
         .set('authorization', 'Bearer ' + access_token)
-        .use(promise)
-        .end();
+        .use(promise);
       if (response.status == 204)
         return true;
       else

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ export function createRequester({config, refresh_token, username, password}) {
       throw Error('unable to authenticate');
     return request
       .use(promise)
-      .set('authorization', 'Bearer ' + client.tokens.access_token)
-      .end();
+      .set('authorization', 'Bearer ' + client.tokens.access_token);
   }
 }


### PR DESCRIPTION
@inchoate @eptify 

Silences the warning `superagentPromisePlugin: Use req.then or req['catch'] instead` from the underlying superagent-promise dependency