### PR TITLE
Make auth-client-js not require a _window object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "authclient",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "client for realmassive auth service",
   "repository": "https://github.com/RealMassive/auth-client-js",
   "dependencies": {

--- a/src/client.js
+++ b/src/client.js
@@ -11,7 +11,13 @@ export default class Client {
 
   constructor(config, refresh_token, _window) {
     this.config = config;
-    this.store = ClientStorage.enabled(_window.localStorage) ? new ClientStorage(_window.localStorage) : null;
+
+    // Only attempt to establish a ClientStorage if a window was passed.
+    // A window should not be passed in a Node.js environment because there
+    // is no window to pass.
+    if (_window) {
+      this.store = ClientStorage.enabled(_window.localStorage) ? new ClientStorage(_window.localStorage) : null;
+    }
     this.tokens = this._setOrRestoreTokens(refresh_token);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,6 @@ import Client from './client';
 export superagent from 'superagent';
 
 export function createClient({config, refresh_token, _window}) {
-  if (!_window)
-    throw Error('cannot create client: _window missing');
   return new Client(config, refresh_token, _window);
 }
 

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -10,7 +10,7 @@ describe('Client', function() {
       throw Error('assertion failed');
   };
   var config = { endpoint: 'https://auth.realmassive.com' };
-  var client = _RMAUTH.createClient({config, _window: window});
+  var client = _RMAUTH.createClient({config});
 
   it('login', function() {
     return client.login('testuser', 'efgh5678@')
@@ -40,43 +40,47 @@ describe('Client', function() {
       });
   });
 
-  /* Tokens */
-  it('stores tokens on login', function() {
-    return client.login('testuser', 'efgh5678@')
-      .then(function(tokens) {
-        assert(tokens.access_token === client.store.getObject("tok").access_token);
-      });
-  });
+  describe('localStorage', function () {
+    var clientWithStorage = _RMAUTH.createClient({config, _window: window});
 
-  it('updates tokens on refresh', function() {
-    return client.refresh()
-      .then(function(tokens) {
-        assert(tokens.access_token === client.store.getObject("tok").access_token);
-      });
-  });
-
-  it('updates tokens on a refresh with a new client', function () {
-    var newClient = _RMAUTH.createClient({
-      config,
-      _window: window
+    /* Tokens */
+    it('stores tokens on login', function() {
+      return clientWithStorage.login('testuser', 'efgh5678@')
+        .then(function(tokens) {
+          assert(tokens.access_token === clientWithStorage.store.getObject("tok").access_token);
+        });
     });
-    return newClient.refresh()
-      .then(function(tokens) {
-        assert(tokens.access_token === client.store.getObject("tok").access_token);
-      });
-  });
 
-  it('updates tokens on reauthenticate', function() {
-    return client.reauthenticate()
-      .then(function(response) {
-        assert(response === true);
-      });
-  });
+    it('updates tokens on refresh', function() {
+      return clientWithStorage.refresh()
+        .then(function(tokens) {
+          assert(tokens.access_token === clientWithStorage.store.getObject("tok").access_token);
+        });
+    });
 
-  it('clears tokens on logout', function() {
-    return client.logout()
-      .then(function(response) {
-        assert(response === true);
+    it('updates tokens on a refresh with a new clientWithStorage', function () {
+      var newClient = _RMAUTH.createClient({
+        config,
+        _window: window
       });
+      return newClient.refresh()
+        .then(function(tokens) {
+          assert(tokens.access_token === clientWithStorage.store.getObject("tok").access_token);
+        });
+    });
+
+    it('updates tokens on reauthenticate', function() {
+      return clientWithStorage.reauthenticate()
+        .then(function(response) {
+          assert(response === true);
+        });
+    });
+
+    it('clears tokens on logout', function() {
+      return clientWithStorage.logout()
+        .then(function(response) {
+          assert(response === true);
+        });
+    });
   });
 });

--- a/test/node/test.js
+++ b/test/node/test.js
@@ -10,14 +10,9 @@ describe('Client', () => {
   const config = { endpoint: 'https://auth.realmassive.com' };
   const username = 'testuser';
   const password = 'efgh5678@';
-  const _window = {
-    localStorage: {
-      setItem: function () {},
-      getItem: function () {}
-    }
-  }
-  const requester = createRequester({config, username, password, _window});
-  const client = createClient({config, _window});
+
+  const requester = createRequester({config, username, password});
+  const client = createClient({config});
 
   it('login', async () => {
     const tokens = await client.login(username, password);


### PR DESCRIPTION
I'm working on pulling some of the experience layer that exists into the admin-panel into a standalone node module. I'd like to expose a CLI as well as a programmatic interface to make it easy to interact with, and be ready to go into an independent experience layer service. However, `auth-client-js` demands that a `window` be passed during construction, but this doesn't make sense in Node.js contexts.