### PR TITLE
Enhance build process to allow consumption by third party modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0"]
+  "presets": ["es2015", "stage-0"],
+  "plugins": ["transform-runtime"]
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,14 +1,51 @@
+var path = require('path');
+
+var babelLoader = path.resolve(__dirname, 'node_modules/babel-loader') +
+    '?' + ['babel-preset-es2015', 'babel-preset-stage-0'].map(function(s) {
+        // Miserable fix from https://github.com/babel/babel-loader/issues/166#issuecomment-160866946
+        return 'presets[]=' + require.resolve(s);
+    }).join(',');
+
 module.exports = function(config) {
   config.set({
+    preprocessors: {
+      'src/**/*.js': ['webpack'],
+      'test/**/*.js': ['webpack']
+    },
     frameworks: [
       'mocha'
     ],
     files: [
-      'dist/authclient.js',
-      'dist/test.js'
+      'node_modules/babel-polyfill/dist/polyfill.js',
+      'test/browser/test.js',
+      'test/node/test.js'
     ],
     browsers: [
       'Chrome'
-    ]
+    ],
+    webpack: {
+        devtool: 'inline-source-map',
+        resolveLoader: {
+            root: path.join(__dirname, "node_modules")
+        },
+        resolve: {
+            root: path.resolve(__dirname, 'src'),
+            modulesDirectories: ['node_modules'],
+            extensions: ['', '.js', '.json']
+        },
+        module: {
+            loaders: [{
+                test: /\.js$/,
+                loaders: [babelLoader],
+                exclude: /node_modules/
+            }, {
+                test: /\.json$/,
+                loader: 'json'
+            }]
+        }
+    },
+    webpackServer: {
+        noInfo: true
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -1,23 +1,28 @@
 {
   "name": "authclient",
-  "version": "1.1.0",
+  "main": "lib/index.js",
+  "version": "1.2.0",
   "description": "client for realmassive auth service",
   "repository": "https://github.com/RealMassive/auth-client-js",
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "superagent": "^1.8.0",
     "superagent-promise-plugin": "^2.1.0"
   },
   "scripts": {
     "lint": "eslint src test",
     "test": "mocha --compilers js:babel-core/register --require babel-polyfill test/node",
-    "test-browser": "npm run build && karma start --single-run",
-    "build": "webpack"
+    "test-browser": "karma start --single-run",
+    "build": "./node_modules/babel-cli/bin/babel.js src --out-dir lib",
+    "postinstall": "npm run build"
   },
   "devDependencies": {
+    "babel-cli": "^6.11.4",
     "babel-core": "^6.7.2",
     "babel-eslint": "^5.0.0",
     "babel-loader": "^6.2.4",
-    "babel-polyfill": "^6.7.2",
+    "babel-plugin-transform-runtime": "^6.12.0",
+    "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "eslint": "~2.2.0",
@@ -26,6 +31,7 @@
     "karma": "^0.13.22",
     "karma-chrome-launcher": "^0.2.2",
     "karma-mocha": "^0.2.2",
+    "karma-webpack": "^1.7.0",
     "mocha": "^2.4.5",
     "superagent-mock": "^1.10.0",
     "webpack": "^1.12.14"

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1,16 +1,17 @@
 /*eslint-disable */
 
 describe('Client', function() {
+  var authclient = require('../../src/index');
   var fixtures = require('../fixtures');
   var mock = require('superagent-mock');
-  mock(_RMAUTH.superagent, fixtures);
+  mock(authclient.superagent, fixtures);
 
   var assert = function(x) {
     if (!x)
       throw Error('assertion failed');
   };
   var config = { endpoint: 'https://auth.realmassive.com' };
-  var client = _RMAUTH.createClient({config});
+  var client = authclient.createClient({config});
 
   it('login', function() {
     return client.login('testuser', 'efgh5678@')
@@ -41,7 +42,7 @@ describe('Client', function() {
   });
 
   describe('localStorage', function () {
-    var clientWithStorage = _RMAUTH.createClient({config, _window: window});
+    var clientWithStorage = authclient.createClient({config, _window: window});
 
     /* Tokens */
     it('stores tokens on login', function() {
@@ -59,7 +60,7 @@ describe('Client', function() {
     });
 
     it('updates tokens on a refresh with a new clientWithStorage', function () {
-      var newClient = _RMAUTH.createClient({
+      var newClient = authclient.createClient({
         config,
         _window: window
       });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ var base = {
         test: path.join(__dirname, 'src'),
         loader: 'babel',
         query: {
-          presets: ['stage-0']
+          presets: ['es2015', 'stage-0']
         }
       }
     ]


### PR DESCRIPTION
@inchoate Ignore everything in the `lib` directory - that is now a directory only for the built results of `src`.

Changes:

- `npm build` now runs the `src` directory through babel, outputting to `lib`. This means that projects consuming the code either as Node.js or Webpack can properly consume the code without having to worry about writing custom loaders, resolvers, or other es6-handling code. This is the way many open source repositories seem to do it, and is probably how this should be done for all of our internal, consumable repositories. There's some work to be done still around proper npm scripts (I believe there's a way to avoid versioning the `lib` dir) but this gets us where we need to be quickly.
- Karma conf updated to use Webpack to automatically babel and build the tests. Now you can run `npm run test-browser` without running `npm build` prior.
- Updated npm scripts to use babel-cli
- Updated tests to refer to pre-built modules instead of the `dist` module